### PR TITLE
sync: mainの変更をdevelopに同期 (mise機能追加)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "22"    # package.json の engines と合わせる
+php = "8.3"    # backend/composer.json と合わせる

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ cd my-project
 - Composer 2.x
 - Git
 
+#### mise を使用した開発環境管理（オプション）
+
+[mise](https://mise.jdx.dev/) を使用することで、Node.js と PHP のバージョンを簡単に管理できます：
+
+```bash
+# mise がインストールされている場合
+mise install  # .mise.toml に記載されたツールを自動インストール
+
+# volta、asdf、nodenv、phpenv など他のバージョン管理ツールとも共存可能
+# mise を使わない場合は、上記の前提条件に従って手動でインストール
+```
+
 ### 開発環境の起動
 
 ```bash


### PR DESCRIPTION
## 概要
mainブランチに直接マージされたmise機能をdevelopブランチに同期します。

## 変更種別
- [x] 🔧 chore: その他の変更（ビルド、設定、ドキュメント等）

## 同期内容
- `.mise.toml` ファイルの追加（Node.js 22、PHP 8.3）
- README.md にmiseの使用方法追加

## 理由
PR #46が誤ってmainブランチに直接マージされたため、developブランチとの同期が必要。

## チェックリスト
- [x] ローカルで動作確認済み
- [x] テストが通っている
- [x] レビュー依頼の準備完了

## マージ方法確認
- [x] main → develop: **Create a merge commit** を使用