### PR TITLE
sync: developをmainと同期

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "22"    # package.json の engines と合わせる
+php = "8.3"    # backend/composer.json と合わせる

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ cd my-project
 - Composer 2.x
 - Git
 
+#### mise を使用した開発環境管理（オプション）
+
+[mise](https://mise.jdx.dev/) を使用することで、Node.js と PHP のバージョンを簡単に管理できます：
+
+```bash
+# mise がインストールされている場合
+mise install  # .mise.toml に記載されたツールを自動インストール
+
+# volta、asdf、nodenv、phpenv など他のバージョン管理ツールとも共存可能
+# mise を使わない場合は、上記の前提条件に従って手動でインストール
+```
+
 ### 開発環境の起動
 
 ```bash


### PR DESCRIPTION
## 概要
developブランチをmainブランチの最新状態と同期します。

## 変更種別
- [x] 🔧 chore: その他の変更（ビルド、設定、ドキュメント等）

## 理由
PR #46が誤ってmainに直接マージされたため、developブランチの同期が必要です。

## 変更内容
- developブランチをmainブランチと同じ状態にする
- mise機能(.mise.toml、README.mdの更新)が含まれる

## チェックリスト
- [x] レビュー依頼の準備完了

## マージ方法確認
- [x] **Create a merge commit** を使用