### PR TITLE
chore: GitHub Actionsのアクションを最新版に更新 (#64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -91,10 +91,10 @@ jobs:
   frontend-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "npm"
@@ -137,7 +137,7 @@ jobs:
       security-events: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -156,7 +156,7 @@ jobs:
           composer audit || true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "npm"


### PR DESCRIPTION
## 概要
GitHub Actionsワークフローで使用されているアクションを最新版に更新しました。

## 関連Issue
closes #64

## 変更種別
- [ ] 🚀 feat: 新機能
- [ ] 🐛 fix: バグ修正
- [x] 🔧 chore: その他の変更（ビルド、設定、ドキュメント等）

## 変更内容
- `actions/checkout@v3` → `actions/checkout@v4` への更新
- `actions/setup-node@v3` → `actions/setup-node@v4` への更新

## 更新理由
1. **セキュリティ改善**: 最新版でのセキュリティパッチ適用
2. **Node.js 22サポート**: より良い互換性
3. **パフォーマンス向上**: 最新版での最適化

## チェックリスト
- [x] ローカルで動作確認済み
- [x] テストが通っている
- [x] レビュー依頼の準備完了

## マージ方法確認
- [x] feature → develop: **Squash and merge** を使用
- [ ] develop → main: **Create a merge commit** を使用
- [ ] hotfix → main: **Squash and merge** を使用