### PR TITLE
fix: README.mdの存在チェック不備を修正してスクリプトエラーを防止 (#84)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,8 @@ PROJECT_NAME_UNDERSCORE=$(echo "${PROJECT_NAME}" | tr '-' '_')
 # テンプレート初期化が完了済みかどうかをREADME.mdで判定
 IS_FIRST_RUN=false
 if [ -f "README.md" ]; then
-  if grep -q "Laravel + Nuxt + PostgreSQL テンプレート" README.md 2>/dev/null && ! grep -q "quick-chef" README.md 2>/dev/null; then
+  if grep -q "Laravel + Nuxt + PostgreSQL テンプレート" README.md && \
+     ! grep -q "quick-chef" README.md; then
     IS_FIRST_RUN=true
   fi
 else

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,12 @@ PROJECT_NAME_UNDERSCORE=$(echo "${PROJECT_NAME}" | tr '-' '_')
 # 初回実行かどうかの判定
 # テンプレート初期化が完了済みかどうかをREADME.mdで判定
 IS_FIRST_RUN=false
-if grep -q "Laravel + Nuxt + PostgreSQL テンプレート" README.md && ! grep -q "quick-chef" README.md; then
+if [ -f "README.md" ]; then
+  if grep -q "Laravel + Nuxt + PostgreSQL テンプレート" README.md 2>/dev/null && ! grep -q "quick-chef" README.md 2>/dev/null; then
+    IS_FIRST_RUN=true
+  fi
+else
+  # README.mdが存在しない場合は初回実行とみなす
   IS_FIRST_RUN=true
 fi
 


### PR DESCRIPTION
## 概要
setup.shでREADME.mdの存在を確認せずにgrepコマンドを実行している問題を修正します。

## 関連Issue
closes #84

## 変更種別
- [x] 🐛 fix: バグ修正

## 問題の詳細

### 現在の問題
```bash
# 26行目 - ファイル存在チェックなし
if grep -q "Laravel + Nuxt + PostgreSQL テンプレート" README.md && \! grep -q "quick-chef" README.md; then
  IS_FIRST_RUN=true
fi
```

### 問題の影響
- README.mdが存在しない場合に「No such file or directory」エラー
- IS_FIRST_RUN判定が正しく動作しない
- 初回実行時のユーザー体験が損なわれる

## 修正内容

### 修正後のコード
```bash
IS_FIRST_RUN=false
if [ -f "README.md" ]; then
  if grep -q "Laravel + Nuxt + PostgreSQL テンプレート" README.md 2>/dev/null && \! grep -q "quick-chef" README.md 2>/dev/null; then
    IS_FIRST_RUN=true
  fi
else
  # README.mdが存在しない場合は初回実行とみなす
  IS_FIRST_RUN=true
fi
```

### 改善点
1. **ファイル存在チェック**: `[ -f "README.md" ]` でファイル存在を確認
2. **エラー抑制**: `2>/dev/null` でgrepのエラー出力を抑制
3. **適切なフォールバック**: README.mdが存在しない場合は初回実行として処理

## チェックリスト
- [x] ローカルで動作確認済み
- [x] エラーハンドリングが適切
- [x] レビュー依頼の準備完了

## マージ方法確認
- [x] feature → develop: **Squash and merge** を使用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **バグ修正**
  * README.mdファイルが存在しない場合でも初回実行として正しく判定されるようになりました。
  * チェック時のエラー出力が抑制され、より安定して動作するよう改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->