### PR TITLE
fix: backend/.env.exampleのAPP_NAME置換で引用符なし形式にも対応 (#97)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -242,8 +242,11 @@ if [ "$CUSTOMIZE_TEMPLATE" = true ]; then
   # backend/.env.exampleの特別処理
   if [ -f "backend/.env.example" ]; then
     info "backend/.env.exampleを更新中..."
-    # より安全な置換：コメントを保持しながらAPP_NAME値のみを置換
+    # bulletproof APP_NAME replacement preventing double-processing and syntax errors
+    # Step 1: Handle quoted values: APP_NAME="value" → APP_NAME="new-value"
     sed -i.bak "s@^APP_NAME=\"[^\"]*\"@APP_NAME=\"${PROJECT_NAME_ESCAPED}\"@g" backend/.env.example
+    # Step 2: Handle unquoted values (skip already quoted lines): APP_NAME=value → APP_NAME="new-value"
+    sed -i.bak "/^APP_NAME=\"/!s@^APP_NAME=\(.*\)@APP_NAME=\"${PROJECT_NAME_ESCAPED}\"@g" backend/.env.example
     rm -f backend/.env.example.bak
     success "backend/.env.exampleの特別処理が完了しました"
   fi


### PR DESCRIPTION
## 概要
setup.shスクリプトのbackend/.env.exampleにおけるAPP_NAME置換処理で、引用符なしの形式（`APP_NAME=value`）にも対応しました。

## 関連Issue
closes #97

## 変更種別
- [x] 🐛 fix: バグ修正

## 変更内容
- backend/.env.exampleのAPP_NAME置換ロジックを修正
- 引用符付き形式（`APP_NAME="value"`）に加えて、引用符なし形式（`APP_NAME=value`）にも対応
- frontend/.env.exampleと同様の2段階処理を適用

## 実装詳細
1. Step 1: 引用符付き形式を処理: `APP_NAME="value"` → `APP_NAME="new-value"`
2. Step 2: 引用符なし形式を処理（既に引用符付きの行はスキップ）: `APP_NAME=value` → `APP_NAME="new-value"`

## テスト
- 引用符付き形式と引用符なし形式の両方で正常に動作することを確認
- 既存の引用符付き形式は二重処理されないことを確認

## チェックリスト
- [x] ローカルで動作確認済み
- [x] 引用符付きと引用符なしの両方の形式をテスト
- [x] レビュー依頼の準備完了

## マージ方法確認
- [x] feature → develop: **Squash and merge** を使用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `--setup-only`フラグを追加し、開発環境のセットアップのみを実行できるようになりました。

* **改善**
  * テンプレートカスタマイズの判定方法が明確化され、より安全かつ繰り返し実行可能になりました。
  * プロジェクト名の指定が柔軟になり、指定がない場合はカレントディレクトリ名を自動使用します。
  * 追加の設定ファイルやREADMEのプレースホルダー置換に対応し、カスタマイズ範囲が拡大しました。

* **その他**
  * 成功メッセージやセクションヘッダーの表示内容が更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->