### PR TITLE
chore: README.mdとgitignoreの記述を修正 (#99)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,4 +136,7 @@ claude-parallel/
 .windsurfrules
 
 # mise version management
-mise.toml
+.mise.toml
+
+# Temporary files
+tmp

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Laravel 12.x + Nuxt.js 3.16 + PostgreSQL 17.x を使用したモダンなウェ�
 
 ```bash
 # 1. GitHubで「Use this template」をクリック、または：
-gh repo create my-new-project --template your-org/laravel-nuxt-template --private
+gh repo create my-new-project --template your-org/laravel_nuxt_postgre_template --private
 
 # 2. クローンしてセットアップ（1コマンドで完了）
 git clone https://github.com/your-org/my-new-project.git
@@ -21,7 +21,7 @@ cd my-new-project
 ### 直接クローンする場合
 
 ```bash
-git clone https://github.com/your-org/laravel-nuxt-template.git my-project
+git clone https://github.com/your-org/laravel_nuxt_postgre_template.git my-project
 cd my-project
 ./setup.sh my-project
 ```


### PR DESCRIPTION
## 概要
Issue #99に対応して、README.mdのプロジェクト名と.gitignoreの記述を修正しました。

## 関連Issue
closes #99

## 変更種別
- [x] 🔧 chore: その他の変更（ビルド、設定、ドキュメント等）

## 変更内容

### README.md
- プロジェクト名を正しく修正
  - `laravel-nuxt-template` → `laravel_nuxt_postgre_template` (2箇所)

### .gitignore
- `mise.toml` → `.mise.toml` (ドットを追加)
- `tmp` ディレクトリを追加

## チェックリスト
- [x] ローカルで動作確認済み
- [x] テストが通っている
- [x] レビュー依頼の準備完了

## マージ方法確認
- [x] feature → develop: **Squash and merge** を使用