### PR TITLE
fix: frontend/layouts/default.vueのフッターのSample Appもセットアップ時に置換 (#102)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -289,6 +289,8 @@ if [ "$CUSTOMIZE_TEMPLATE" = true ]; then
       PROJECT_INITIALS="APP"
     fi
     sed -i.bak "s/>LNT</>$PROJECT_INITIALS</g" frontend/layouts/default.vue
+    # フッターの「Sample App」を置換
+    sed -i.bak "s@Sample App@${PROJECT_NAME_HYPHEN_ESCAPED}@g" frontend/layouts/default.vue
     rm -f frontend/layouts/default.vue.bak
     success "frontend/layouts/default.vueの特別処理が完了しました"
   fi


### PR DESCRIPTION
## 概要
setup.shスクリプトのfrontend/layouts/default.vue処理部分に、フッターの「Sample App」文字列をプロジェクト名に置換する処理を追加しました。

## 関連Issue
closes #102

## 変更種別
- [x] 🐛 fix: バグ修正

## 変更内容
- setup.shのfrontend/layouts/default.vue処理部分に以下の処理を追加：
  - フッターの「Sample App」をプロジェクト名（PROJECT_NAME_HYPHEN_ESCAPED）に置換
  - 既存の処理に合わせて安全で冪等性を保つ置換を実装

## テスト結果
- テスト用ファイルで「Sample App」→「MyProject」への置換が正常に動作することを確認

## チェックリスト
- [x] ローカルで動作確認済み
- [x] テストが通っている
- [x] レビュー依頼の準備完了

## マージ方法確認
- [x] feature → develop: **Squash and merge** を使用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * フッターのラベルがプロジェクト名に自動的に置き換わるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->